### PR TITLE
Bugfix: BL11900 Sorting Error

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # hvt-geolocation
 
-A Serverless Node lambda (GeolocationFunction) for querying, sorting (nearest-frist) and paginating ATFs based on a supplied postcode.
+A Serverless Node lambda (GeolocationFunction) for querying, sorting (nearest-first) and paginating ATFs based on a supplied postcode.
 
 ## Requirements
 

--- a/README.md
+++ b/README.md
@@ -20,7 +20,15 @@ A Serverless Node lambda (GeolocationFunction) for querying, sorting (nearest-fi
 1. To ensure that the lambdas have been successfully served, run the following command in a separate terminal:
     - `curl --request GET http://localhost:3008/<POSTCODE-HERE>?page=1&limit=5`
     - the response should be in the following format: `{ "Items": [ <ATF-1>, <ATF-2>, ... ] }`
+    
+### Run and watch Locally
 
+As steps above but instead of `build:dev`
+- `npm run watch:dev`
+
+and in a separate terminal, run
+
+- `npm run start:dev`
 
 ## Debug Locally (VS Code only)
 

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "build:dev": "webpack-cli --config webpack.development.js",
     "build:prod": "webpack-cli --config webpack.production.js",
     "start:dev": "sam local start-api -p 3008 --docker-network hvt-network",
+    "watch:dev": "webpack-cli --config webpack.development.watch.js",
     "invoke": "sam local invoke"
   },
   "contributors": [

--- a/src/handler/index.ts
+++ b/src/handler/index.ts
@@ -62,6 +62,8 @@ export const handler = async (event: APIGatewayProxyEvent, context: Context): Pr
   // Filter out those with no availability
   if (removeNoAvailabilityFlag) {
     try {
+      atfs.Items = filterAtfs.removeAtfsWithNoGeolocationData(atfs.Items);
+      log.info(`ATFs after filtering out those with no geolocation data [${atfs.Count}]`);
       atfs.Items = filterAtfs.removeAtfsWithNoAvailability(atfs.Items);
       log.info(`ATFs after filtering out those with no availability [${atfs.Count}]`);
     } catch (error) {
@@ -77,7 +79,6 @@ export const handler = async (event: APIGatewayProxyEvent, context: Context): Pr
   } catch (error) {
     const errorString: string = JSON.stringify(error, Object.getOwnPropertyNames(error));
     log.error(`An unexpected error occurred when sorting ATFs: ${errorString}`);
-    throw error;
   }
 
   // Paginate ATFs

--- a/src/handler/index.ts
+++ b/src/handler/index.ts
@@ -59,11 +59,11 @@ export const handler = async (event: APIGatewayProxyEvent, context: Context): Pr
       log.error(`An unexpected error occurred when fetching ATFs: ${errorString}`);
       throw error;
     });
-  // Filter out those with no availability
+  // Filtering
+  atfs.Items = filterAtfs.removeAtfsWithNoGeolocationData(atfs.Items);
+  log.info(`ATFs after filtering out those with no geolocation data [${atfs.Count}]`);
   if (removeNoAvailabilityFlag) {
     try {
-      atfs.Items = filterAtfs.removeAtfsWithNoGeolocationData(atfs.Items);
-      log.info(`ATFs after filtering out those with no geolocation data [${atfs.Count}]`);
       atfs.Items = filterAtfs.removeAtfsWithNoAvailability(atfs.Items);
       log.info(`ATFs after filtering out those with no availability [${atfs.Count}]`);
     } catch (error) {

--- a/src/handler/index.ts
+++ b/src/handler/index.ts
@@ -60,7 +60,7 @@ export const handler = async (event: APIGatewayProxyEvent, context: Context): Pr
       throw error;
     });
   // Filtering
-  atfs.Items = filterAtfs.removeAtfsWithNoGeolocationData(atfs.Items);
+  atfs.Items = filterAtfs.removeAtfsWithNoGeolocationData(atfs.Items, log);
   log.info(`ATFs after filtering out those with no geolocation data [${atfs.Items.length}]`);
   if (removeNoAvailabilityFlag) {
     try {
@@ -89,9 +89,8 @@ export const handler = async (event: APIGatewayProxyEvent, context: Context): Pr
     const errorString: string = JSON.stringify(error, Object.getOwnPropertyNames(error));
     log.warn(`An unexpected error occurred when paginating ATFs: ${errorString}`);
   }
-
   return Promise.resolve({
     statusCode: 200,
-    body: JSON.stringify({ Items: atfs.Items, Count: atfs.Items.length, ScannedCount: atfs.Count }),
+    body: JSON.stringify({ Items: atfs.Items, Count: atfs.Items.length, ScannedCount: atfs.Items.length }),
   });
 };

--- a/src/handler/index.ts
+++ b/src/handler/index.ts
@@ -61,11 +61,11 @@ export const handler = async (event: APIGatewayProxyEvent, context: Context): Pr
     });
   // Filtering
   atfs.Items = filterAtfs.removeAtfsWithNoGeolocationData(atfs.Items);
-  log.info(`ATFs after filtering out those with no geolocation data [${atfs.Count}]`);
+  log.info(`ATFs after filtering out those with no geolocation data [${atfs.Items.length}]`);
   if (removeNoAvailabilityFlag) {
     try {
       atfs.Items = filterAtfs.removeAtfsWithNoAvailability(atfs.Items);
-      log.info(`ATFs after filtering out those with no availability [${atfs.Count}]`);
+      log.info(`ATFs after filtering out those with no availability [${atfs.Items.length}]`);
     } catch (error) {
       const errorString: string = JSON.stringify(error, Object.getOwnPropertyNames(error));
       log.error(`An unexpected error occurred when filtering ATFs: ${errorString}`);
@@ -75,7 +75,7 @@ export const handler = async (event: APIGatewayProxyEvent, context: Context): Pr
   // Sort ATFs
   try {
     atfs.Items = sortAtfs.nearestFirst(geoLocation, atfs.Items);
-    log.info(`Sorted ATFs [${atfs.Count}]`);
+    log.info(`Sorted ATFs [${atfs.Items.length}]`);
   } catch (error) {
     const errorString: string = JSON.stringify(error, Object.getOwnPropertyNames(error));
     log.error(`An unexpected error occurred when sorting ATFs: ${errorString}`);
@@ -84,7 +84,7 @@ export const handler = async (event: APIGatewayProxyEvent, context: Context): Pr
   // Paginate ATFs
   try {
     atfs.Items = pagination.paginate(atfs.Items, page, limit);
-    log.info(`Paginated ATFs [${atfs.Count}]; page [${page}], limit [${limit}]`);
+    log.info(`Paginated ATFs [${atfs.Items.length}]; page [${page}], limit [${limit}]`);
   } catch (error) {
     const errorString: string = JSON.stringify(error, Object.getOwnPropertyNames(error));
     log.warn(`An unexpected error occurred when paginating ATFs: ${errorString}`);

--- a/src/lib/filterAtfs.ts
+++ b/src/lib/filterAtfs.ts
@@ -1,10 +1,16 @@
 import { utcToZonedTime } from 'date-fns-tz';
 import { isValid } from 'date-fns';
 import { AuthorisedTestingFacility } from '../models/authorisedTestingFacility';
+import { Logger } from '../util/logger';
 
 // eslint-disable-next-line max-len
-const removeAtfsWithNoGeolocationData = (atfs: AuthorisedTestingFacility[]): AuthorisedTestingFacility[] => atfs.filter((atf) => atf?.geoLocation != null
-  && atf?.geoLocation?.lat != null && atf?.geoLocation?.long != null);
+const removeAtfsWithNoGeolocationData = (atfs: AuthorisedTestingFacility[], logger: Logger): AuthorisedTestingFacility[] => atfs.filter((atf) => {
+  if (atf?.geoLocation != null && atf?.geoLocation?.lat != null && atf?.geoLocation?.long != null) {
+    return true;
+  }
+  logger.warn(`ATF removed from results due to an error in geolocation data. ID: ${atf.id}`);
+  return false;
+});
 
 // eslint-disable-next-line max-len
 const removeAtfsWithNoAvailability = (atfs: AuthorisedTestingFacility[]): AuthorisedTestingFacility[] => atfs.filter((atf) => atf?.availability?.isAvailable !== false

--- a/src/lib/filterAtfs.ts
+++ b/src/lib/filterAtfs.ts
@@ -3,15 +3,20 @@ import { isValid } from 'date-fns';
 import { AuthorisedTestingFacility } from '../models/authorisedTestingFacility';
 
 // eslint-disable-next-line max-len
+const removeAtfsWithNoGeolocationData = (items: AuthorisedTestingFacility[]): AuthorisedTestingFacility[] => items.filter((item) => item.geoLocation
+   && item.geoLocation.lat && item.geoLocation.long);
+
+// eslint-disable-next-line max-len
 const removeAtfsWithNoAvailability = (items: AuthorisedTestingFacility[]): AuthorisedTestingFacility[] => items.filter((item) => item?.availability?.isAvailable !== false
-        || !isAvailabilityInformationUpToDate(item?.availability?.endDate));
+  || !isAvailabilityInformationUpToDate(item?.availability?.endDate));
 
 const isAvailabilityInformationUpToDate = (date: string | undefined): boolean => date
-    && isValid(date) && !isDateBeforeToday(date);
+  && isValid(date) && !isDateBeforeToday(date);
 
 // eslint-disable-next-line max-len
 const isDateBeforeToday = (date: string): boolean => utcToZonedTime(new Date(date), process.env.TIMEZONE) < utcToZonedTime(new Date(), process.env.TIMEZONE);
 
 export const filterAtfs = {
   removeAtfsWithNoAvailability,
+  removeAtfsWithNoGeolocationData,
 };

--- a/src/lib/filterAtfs.ts
+++ b/src/lib/filterAtfs.ts
@@ -3,12 +3,8 @@ import { isValid } from 'date-fns';
 import { AuthorisedTestingFacility } from '../models/authorisedTestingFacility';
 
 // eslint-disable-next-line max-len
-const removeAtfsWithNoGeolocationData = (atfs: AuthorisedTestingFacility[]): AuthorisedTestingFacility[] => atfs.filter((atf) => {
-  if (atf.name === 'ATF1') {
-    console.log(`ATF1: ${(atf.geoLocation && atf.geoLocation.lat && atf.geoLocation.long).toString()}`);
-  }
-  return atf.geoLocation && atf.geoLocation.lat && atf.geoLocation.long;
-});
+const removeAtfsWithNoGeolocationData = (atfs: AuthorisedTestingFacility[]): AuthorisedTestingFacility[] => atfs.filter((atf) => atf?.geoLocation != null
+  && atf?.geoLocation?.lat != null && atf?.geoLocation?.long != null);
 
 // eslint-disable-next-line max-len
 const removeAtfsWithNoAvailability = (atfs: AuthorisedTestingFacility[]): AuthorisedTestingFacility[] => atfs.filter((atf) => atf?.availability?.isAvailable !== false

--- a/src/lib/filterAtfs.ts
+++ b/src/lib/filterAtfs.ts
@@ -3,12 +3,16 @@ import { isValid } from 'date-fns';
 import { AuthorisedTestingFacility } from '../models/authorisedTestingFacility';
 
 // eslint-disable-next-line max-len
-const removeAtfsWithNoGeolocationData = (items: AuthorisedTestingFacility[]): AuthorisedTestingFacility[] => items.filter((item) => item.geoLocation
-   && item.geoLocation.lat && item.geoLocation.long);
+const removeAtfsWithNoGeolocationData = (atfs: AuthorisedTestingFacility[]): AuthorisedTestingFacility[] => atfs.filter((atf) => {
+  if (atf.name === 'ATF1') {
+    console.log(`ATF1: ${(atf.geoLocation && atf.geoLocation.lat && atf.geoLocation.long).toString()}`);
+  }
+  return atf.geoLocation && atf.geoLocation.lat && atf.geoLocation.long;
+});
 
 // eslint-disable-next-line max-len
-const removeAtfsWithNoAvailability = (items: AuthorisedTestingFacility[]): AuthorisedTestingFacility[] => items.filter((item) => item?.availability?.isAvailable !== false
-  || !isAvailabilityInformationUpToDate(item?.availability?.endDate));
+const removeAtfsWithNoAvailability = (atfs: AuthorisedTestingFacility[]): AuthorisedTestingFacility[] => atfs.filter((atf) => atf?.availability?.isAvailable !== false
+  || !isAvailabilityInformationUpToDate(atf?.availability?.endDate));
 
 const isAvailabilityInformationUpToDate = (date: string | undefined): boolean => date
   && isValid(date) && !isDateBeforeToday(date);

--- a/tests/lib/filterAtfs.test.ts
+++ b/tests/lib/filterAtfs.test.ts
@@ -1,5 +1,6 @@
 import { AuthorisedTestingFacility } from '../../src/models/authorisedTestingFacility';
 import { filterAtfs } from '../../src/lib/filterAtfs';
+import { Logger, logger } from '../../src/util/logger';
 
 describe('filterAtfs library unit tests', () => {
   describe('removeAtfsWithNoAvailability tests', () => {
@@ -83,6 +84,7 @@ describe('filterAtfs library unit tests', () => {
   });
 
   describe('removeAtfsWithNoGeolocationData', () => {
+    const log: Logger = logger.create('apiRequestId', 'correlationId');
     test('ATFs with no geolocation property are removed from the list', () => {
       const atfs: AuthorisedTestingFacility[] = <AuthorisedTestingFacility[]><unknown>[
         { availability: { isAvailable: false } },
@@ -90,7 +92,7 @@ describe('filterAtfs library unit tests', () => {
         { geoLocation: { lat: 4, long: 2 } },
         { geoLocation: { lat: 2, long: 4 } },
       ];
-      const result: AuthorisedTestingFacility[] = filterAtfs.removeAtfsWithNoGeolocationData(atfs);
+      const result: AuthorisedTestingFacility[] = filterAtfs.removeAtfsWithNoGeolocationData(atfs, log);
       const expectedAtfs: AuthorisedTestingFacility[] = <AuthorisedTestingFacility[]><unknown>[
         { geoLocation: { lat: 4, long: 2 } },
         { geoLocation: { lat: 2, long: 4 } },
@@ -103,7 +105,7 @@ describe('filterAtfs library unit tests', () => {
         { geoLocation: { lat: 4, long: 2 } },
         { geoLocation: { lat: 2, long: 4 } },
       ];
-      const result: AuthorisedTestingFacility[] = filterAtfs.removeAtfsWithNoGeolocationData(atfs);
+      const result: AuthorisedTestingFacility[] = filterAtfs.removeAtfsWithNoGeolocationData(atfs, log);
       expect(result).toEqual(atfs);
     });
 
@@ -113,7 +115,7 @@ describe('filterAtfs library unit tests', () => {
         { geoLocation: { lat: null, long: 4 } },
         { geoLocation: { lat: undefined, long: 3 } },
       ];
-      const result: AuthorisedTestingFacility[] = filterAtfs.removeAtfsWithNoGeolocationData(atfs);
+      const result: AuthorisedTestingFacility[] = filterAtfs.removeAtfsWithNoGeolocationData(atfs, log);
       expect(result).toEqual([]);
     });
 
@@ -123,7 +125,7 @@ describe('filterAtfs library unit tests', () => {
         { geoLocation: { lat: null, long: 4 } },
         { geoLocation: { lat: undefined, long: 3 } },
       ];
-      const result: AuthorisedTestingFacility[] = filterAtfs.removeAtfsWithNoGeolocationData(atfs);
+      const result: AuthorisedTestingFacility[] = filterAtfs.removeAtfsWithNoGeolocationData(atfs, log);
       expect(result).toEqual([]);
     });
 
@@ -134,7 +136,7 @@ describe('filterAtfs library unit tests', () => {
         { availability: { isAvailable: false } },
         { availability: { isAvailable: false } },
       ];
-      const result: AuthorisedTestingFacility[] = filterAtfs.removeAtfsWithNoGeolocationData(atfs);
+      const result: AuthorisedTestingFacility[] = filterAtfs.removeAtfsWithNoGeolocationData(atfs, log);
       expect(result).toEqual([]);
     });
   });

--- a/tests/lib/filterAtfs.test.ts
+++ b/tests/lib/filterAtfs.test.ts
@@ -81,4 +81,61 @@ describe('filterAtfs library unit tests', () => {
       expect(result).toEqual(atfs);
     });
   });
+
+  describe('removeAtfsWithNoGeolocationData', () => {
+    test('ATFs with no geolocation property are removed from the list', () => {
+      const atfs: AuthorisedTestingFacility[] = <AuthorisedTestingFacility[]><unknown>[
+        { availability: { isAvailable: false } },
+        { availability: { isAvailable: false } },
+        { geoLocation: { lat: 4, long: 2 } },
+        { geoLocation: { lat: 2, long: 4 } },
+      ];
+      const result: AuthorisedTestingFacility[] = filterAtfs.removeAtfsWithNoGeolocationData(atfs);
+      const expectedAtfs: AuthorisedTestingFacility[] = <AuthorisedTestingFacility[]><unknown>[
+        { geoLocation: { lat: 4, long: 2 } },
+        { geoLocation: { lat: 2, long: 4 } },
+      ];
+      expect(result).toEqual(expectedAtfs);
+    });
+
+    test('ATFs with geolocation and a latitude and longitude are not removed', () => {
+      const atfs: AuthorisedTestingFacility[] = <AuthorisedTestingFacility[]><unknown>[
+        { geoLocation: { lat: 4, long: 2 } },
+        { geoLocation: { lat: 2, long: 4 } },
+      ];
+      const result: AuthorisedTestingFacility[] = filterAtfs.removeAtfsWithNoGeolocationData(atfs);
+      expect(result).toEqual(atfs);
+    });
+
+    test('ATFs with missing latitude property are removed from the list', () => {
+      const atfs: AuthorisedTestingFacility[] = <AuthorisedTestingFacility[]><unknown>[
+        { geoLocation: { long: 5 } },
+        { geoLocation: { lat: null, long: 4 } },
+        { geoLocation: { lat: undefined, long: 3 } },
+      ];
+      const result: AuthorisedTestingFacility[] = filterAtfs.removeAtfsWithNoGeolocationData(atfs);
+      expect(result).toEqual([]);
+    });
+
+    test('ATFs with missing longitude property are removed from the list', () => {
+      const atfs: AuthorisedTestingFacility[] = <AuthorisedTestingFacility[]><unknown>[
+        { geoLocation: { long: 5 } },
+        { geoLocation: { lat: null, long: 4 } },
+        { geoLocation: { lat: undefined, long: 3 } },
+      ];
+      const result: AuthorisedTestingFacility[] = filterAtfs.removeAtfsWithNoGeolocationData(atfs);
+      expect(result).toEqual([]);
+    });
+
+    test('an empty list is returned if none of the ATFs have a geolocation property', () => {
+      const atfs: AuthorisedTestingFacility[] = <AuthorisedTestingFacility[]><unknown>[
+        { availability: { isAvailable: false } },
+        { availability: { isAvailable: false } },
+        { availability: { isAvailable: false } },
+        { availability: { isAvailable: false } },
+      ];
+      const result: AuthorisedTestingFacility[] = filterAtfs.removeAtfsWithNoGeolocationData(atfs);
+      expect(result).toEqual([]);
+    });
+  });
 });

--- a/webpack.development.watch.js
+++ b/webpack.development.watch.js
@@ -1,0 +1,8 @@
+const { merge } = require('webpack-merge');
+const common = require('./webpack.common.js');
+
+module.exports = merge(common, {
+  mode: 'development',
+  devtool: 'source-map',
+  watch: true
+});


### PR DESCRIPTION
## Description

A bug was discovered on int env where a single ATF having missing geolocation data was causing an error and preventing any results from being shown. This change will remove any ATFs from the results list that have missing geolocation data and log those that are removed. 

Related issue: https://jira.dvsacloud.uk/browse/BL-11900


## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)


## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective or that my feature works
