### PR TITLE
BL11930 Fix bug in filtering by availability

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -8,8 +8,5 @@
         "alwaysTryTypes": true
       }
     }
-  },
-  "rules": {
-    "max-len": ["error", { "code": 120 }] // Set default max line length
   }
 }

--- a/src/lib/filterAtfs.ts
+++ b/src/lib/filterAtfs.ts
@@ -2,14 +2,11 @@ import { utcToZonedTime } from 'date-fns-tz';
 import { isValid, parseISO } from 'date-fns';
 import { AuthorisedTestingFacility } from '../models/authorisedTestingFacility';
 
-// eslint-disable-next-line max-len
 const removeAtfsWithNoAvailability = (items: AuthorisedTestingFacility[]): AuthorisedTestingFacility[] => items.filter((item) => item?.availability?.isAvailable !== false
         || !isAvailabilityInformationUpToDate(parseISO(item?.availability?.endDate)));
 
-// eslint-disable-next-line max-len
 const isAvailabilityInformationUpToDate = (date: Date | undefined): boolean => (date ? isValid(date) && !isDateBeforeToday(date) : false);
 
-// eslint-disable-next-line max-len
 const isDateBeforeToday = (date: Date): boolean => utcToZonedTime(new Date(date), process.env.TIMEZONE) < utcToZonedTime(new Date(), process.env.TIMEZONE);
 
 export const filterAtfs = {

--- a/src/lib/filterAtfs.ts
+++ b/src/lib/filterAtfs.ts
@@ -1,16 +1,16 @@
 import { utcToZonedTime } from 'date-fns-tz';
-import { isValid } from 'date-fns';
+import { isValid, parseISO } from 'date-fns';
 import { AuthorisedTestingFacility } from '../models/authorisedTestingFacility';
 
 // eslint-disable-next-line max-len
 const removeAtfsWithNoAvailability = (items: AuthorisedTestingFacility[]): AuthorisedTestingFacility[] => items.filter((item) => item?.availability?.isAvailable !== false
-        || !isAvailabilityInformationUpToDate(item?.availability?.endDate));
-
-const isAvailabilityInformationUpToDate = (date: string | undefined): boolean => date
-    && isValid(date) && !isDateBeforeToday(date);
+        || !isAvailabilityInformationUpToDate(parseISO(item?.availability?.endDate)));
 
 // eslint-disable-next-line max-len
-const isDateBeforeToday = (date: string): boolean => utcToZonedTime(new Date(date), process.env.TIMEZONE) < utcToZonedTime(new Date(), process.env.TIMEZONE);
+const isAvailabilityInformationUpToDate = (date: Date | undefined): boolean => (date ? isValid(date) && !isDateBeforeToday(date) : false);
+
+// eslint-disable-next-line max-len
+const isDateBeforeToday = (date: Date): boolean => utcToZonedTime(new Date(date), process.env.TIMEZONE) < utcToZonedTime(new Date(), process.env.TIMEZONE);
 
 export const filterAtfs = {
   removeAtfsWithNoAvailability,

--- a/src/lib/sortAtfs.ts
+++ b/src/lib/sortAtfs.ts
@@ -31,7 +31,6 @@ const nearestFirst = (geoLocation: GeoLocation, items: AuthorisedTestingFacility
     atf.geoLocation.distance = Number((distance / 1609).toFixed(2)); // d in miles to 2 decimal points
   });
 
-  // eslint-disable-next-line max-len
   items.sort((a: AuthorisedTestingFacility, b: AuthorisedTestingFacility) => a.geoLocation.distance - b.geoLocation.distance);
 
   return items;

--- a/tests/lib/filterAtfs.test.ts
+++ b/tests/lib/filterAtfs.test.ts
@@ -3,12 +3,14 @@ import { filterAtfs } from '../../src/lib/filterAtfs';
 
 describe('filterAtfs library unit tests', () => {
   describe('removeAtfsWithNoAvailability tests', () => {
-    const futureEndDate = new Date().setDate(new Date().getDate() + 5);
+    const futureEndDate = new Date();
+    futureEndDate.setDate(new Date().getDate() + 5);
+    const futureEndDateIsoString = futureEndDate.toISOString();
     test('ATFs with no information should not be removed from the list returned', () => {
       const atfs: AuthorisedTestingFacility[] = <AuthorisedTestingFacility[]><unknown>[
         { availability: { isAvailable: undefined, endDate: futureEndDate } },
-        { availability: { isAvailable: true, endDate: futureEndDate } },
-        { availability: { isAvailable: true, endDate: futureEndDate } },
+        { availability: { isAvailable: true, endDate: futureEndDateIsoString } },
+        { availability: { isAvailable: true, endDate: futureEndDateIsoString } },
       ];
       const result: AuthorisedTestingFacility[] = filterAtfs.removeAtfsWithNoAvailability(atfs);
       expect(result).toEqual(atfs);
@@ -16,22 +18,22 @@ describe('filterAtfs library unit tests', () => {
 
     test('ATFs with no availability should be removed from the list returned', () => {
       const atfs: AuthorisedTestingFacility[] = <AuthorisedTestingFacility[]><unknown>[
-        { availability: { isAvailable: false, endDate: futureEndDate } },
-        { availability: { isAvailable: true, endDate: futureEndDate } },
-        { availability: { isAvailable: false, endDate: futureEndDate } },
+        { availability: { isAvailable: false, endDate: futureEndDateIsoString } },
+        { availability: { isAvailable: true, endDate: futureEndDateIsoString } },
+        { availability: { isAvailable: false, endDate: futureEndDateIsoString } },
       ];
       const result: AuthorisedTestingFacility[] = filterAtfs.removeAtfsWithNoAvailability(atfs);
       const expectedAtfs: AuthorisedTestingFacility[] = <AuthorisedTestingFacility[]><unknown>[
-        { availability: { isAvailable: true, endDate: futureEndDate } },
+        { availability: { isAvailable: true, endDate: futureEndDateIsoString } },
       ];
       expect(result).toEqual(expectedAtfs);
     });
 
     test('ATFs with availability should not be removed from the list returned', () => {
       const atfs: AuthorisedTestingFacility[] = <AuthorisedTestingFacility[]><unknown>[
-        { availability: { isAvailable: true, endDate: futureEndDate } },
-        { availability: { isAvailable: true, endDate: futureEndDate } },
-        { availability: { isAvailable: true, endDate: futureEndDate } },
+        { availability: { isAvailable: true, endDate: futureEndDateIsoString } },
+        { availability: { isAvailable: true, endDate: futureEndDateIsoString } },
+        { availability: { isAvailable: true, endDate: futureEndDateIsoString } },
       ];
       const result: AuthorisedTestingFacility[] = filterAtfs.removeAtfsWithNoAvailability(atfs);
       expect(result).toEqual(atfs);
@@ -46,18 +48,19 @@ describe('filterAtfs library unit tests', () => {
     });
 
     test('ATFs with isAvailable set to false but with an end date in the past should not be removed', () => {
-      const yesterday = new Date().setDate(new Date().getDate() - 1);
+      const yesterday = new Date();
+      yesterday.setDate(new Date().getDate() - 1);
       const oneHourInMs = 1000 * 60 * 60;
-      const dateOneHourAgo = Date.now() - oneHourInMs;
+      const dateOneHourAgo = new Date(Date.now() - oneHourInMs).toISOString();
 
       const atfs: AuthorisedTestingFacility[] = <AuthorisedTestingFacility[]><unknown>[
-        { availability: { isAvailable: false, endDate: yesterday } },
+        { availability: { isAvailable: false, endDate: yesterday.toISOString() } },
         { availability: { isAvailable: false, endDate: dateOneHourAgo } },
-        { availability: { isAvailable: false, endDate: futureEndDate } },
+        { availability: { isAvailable: false, endDate: futureEndDateIsoString } },
       ];
       const result: AuthorisedTestingFacility[] = filterAtfs.removeAtfsWithNoAvailability(atfs);
       const expectedAtfs: AuthorisedTestingFacility[] = <AuthorisedTestingFacility[]><unknown>[
-        { availability: { isAvailable: false, endDate: yesterday } },
+        { availability: { isAvailable: false, endDate: yesterday.toISOString() } },
         { availability: { isAvailable: false, endDate: dateOneHourAgo } },
       ];
       expect(result).toEqual(expectedAtfs);
@@ -68,6 +71,7 @@ describe('filterAtfs library unit tests', () => {
         { availability: { isAvailable: false, endDate: 102029222222292e9 } },
         { availability: { isAvailable: false, endDate: '' } },
         { availability: { isAvailable: false, endDate: NaN } },
+        { availability: { isAvailable: false, endDate: undefined } },
       ];
       const result: AuthorisedTestingFacility[] = filterAtfs.removeAtfsWithNoAvailability(atfs);
       expect(result).toEqual(atfs);


### PR DESCRIPTION
End date must be parsed before being passed to date-fns function

## Description

Include a summary of the change here.

Related issue: https://jira.dvsacloud.uk/browse/BL-11930

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)


## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective or that my feature works
