### PR TITLE
BL-11944 Fix bug in pagination by resetting ScannedCount to original

### DIFF
--- a/src/handler/index.ts
+++ b/src/handler/index.ts
@@ -91,6 +91,6 @@ export const handler = async (event: APIGatewayProxyEvent, context: Context): Pr
   }
   return Promise.resolve({
     statusCode: 200,
-    body: JSON.stringify({ Items: atfs.Items, Count: atfs.Items.length, ScannedCount: atfs.Items.length }),
+    body: JSON.stringify({ Items: atfs.Items, Count: atfs.Items.length, ScannedCount: atfs.Count }),
   });
 };

--- a/tests/handler/index.test.ts
+++ b/tests/handler/index.test.ts
@@ -64,7 +64,7 @@ describe('Test lambda handler', () => {
     expect(res.body).toEqual(JSON.stringify({
       Items: paginatedAtfsMock,
       Count: paginatedAtfsMock.length,
-      ScannedCount: paginatedAtfsMock.length,
+      ScannedCount: unsortedAtfs.length,
     }));
   });
 
@@ -245,7 +245,7 @@ describe('Test lambda handler', () => {
     expect(res.body).toEqual(JSON.stringify({
       Items: expectedAtfs,
       Count: expectedAtfs.length,
-      ScannedCount: expectedAtfs.length,
+      ScannedCount: unsortedAtfs.length,
     }));
   });
 


### PR DESCRIPTION
## Description

ScannedCount was recently changed to the length of the ATF array rather than the original Count as filtering removes items and the scanned count was not updated but this broke the pagination on the frontend as it seemed to return a count of the items on one page rather than the total.

MR resets to the original value in order to fix the bug. 

Related issue: https://jira.dvsacloud.uk/browse/BL-11944

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)


## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective or that my feature works
