### PR TITLE
Remove .env from prod build and optionally pass in commit hash

### DIFF
--- a/webpack.common.js
+++ b/webpack.common.js
@@ -1,9 +1,7 @@
 const path = require('path');
 const AwsSamPlugin = require('aws-sam-webpack-plugin');
-const CopyPlugin = require('copy-webpack-plugin');
 
 const awsSamPlugin = new AwsSamPlugin({ vscodeDebug: false });
-const lambdaName = 'GeolocationFunction'; // must correspond to lambda name in template.yml
 
 module.exports = {
   // Loads the entry object from the AWS::Serverless::Function resources in your
@@ -40,11 +38,6 @@ module.exports = {
 
   // Add the AWS SAM Webpack plugin
   plugins: [
-    awsSamPlugin,
-    new CopyPlugin({
-      patterns: [
-        { from: './.env', to: `.aws-sam/build/${lambdaName}/` },
-      ],
-    }),
+    awsSamPlugin
   ],
 };

--- a/webpack.development.js
+++ b/webpack.development.js
@@ -1,7 +1,16 @@
 const { merge } = require('webpack-merge');
+const CopyPlugin = require('copy-webpack-plugin');
 const common = require('./webpack.common.js');
+const lambdaName = 'GeolocationFunction'; // must correspond to lambda name in template.yml
 
 module.exports = merge(common, {
   mode: 'development',
   devtool: 'source-map',
+  plugins: [
+    new CopyPlugin({
+      patterns: [
+        { from: './.env', to: `.aws-sam/build/${lambdaName}/` },
+      ],
+    }),
+  ],
 });

--- a/webpack.development.watch.js
+++ b/webpack.development.watch.js
@@ -1,8 +1,6 @@
 const { merge } = require('webpack-merge');
-const common = require('./webpack.common.js');
+const development = require('./webpack.development.js');
 
-module.exports = merge(common, {
-  mode: 'development',
-  devtool: 'source-map',
+module.exports = merge(development, {
   watch: true
 });

--- a/webpack.production.js
+++ b/webpack.production.js
@@ -5,8 +5,9 @@ const archiver = require('archiver');
 const branchName = require('current-git-branch');
 
 const LAMBDA_NAME = 'GeolocationFunction';
-const OUTPUT_FOLDER = './dist'
-const BUILD_VERSION = branchName().replace("/","-");
+const OUTPUT_FOLDER = './dist';
+const REPO_NAME = 'hvt-geolocation';
+const BRANCH_NAME = branchName().replace("/","-");
 
 class BundlePlugin {
   constructor(params) {
@@ -53,17 +54,20 @@ class BundlePlugin {
   }
 };
 
-module.exports = merge(common, {
-  mode: 'production',
-  plugins: [
-    new BundlePlugin({
-      archives: [
-        {
-          inputPath: `.aws-sam/build/${LAMBDA_NAME}`,
-          outputPath: `${OUTPUT_FOLDER}`,
-          outputName: `HVT-${LAMBDA_NAME}-${BUILD_VERSION}`,
-        }
-      ],
-    }),
-  ],
-});
+module.exports = env => {
+  let commit = env ? env.commit ? env.commit : 'local' : 'local' ;
+  return merge(common, {
+    mode: 'production',
+    plugins: [
+      new BundlePlugin({
+        archives: [
+          {
+            inputPath: `.aws-sam/build/${LAMBDA_NAME}`,
+            outputPath: `${OUTPUT_FOLDER}`,
+            outputName: `${REPO_NAME}-${BRANCH_NAME}-${commit}`,
+          }
+        ],
+      }),
+    ],
+  });
+}


### PR DESCRIPTION
## Description

- Can now optionally pass in `env.commit=<something>` when building in the pipeline
so the zip file is named correctly through build config files, not through
the Jenkinsfile scripts
- Pipeline can now call build command:
`npm run build:prod -- --env.commit=<commit>`
- Also remove the .env file from prod builds as this file is only required
for dev builds and should not be included
- Ticket #BL-11943

Related issue: #BL-11943

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)


## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have added tests that prove my fix is effective or that my feature works
